### PR TITLE
fix: only update changelogs when version is different

### DIFF
--- a/src/core/changelog.ts
+++ b/src/core/changelog.ts
@@ -43,7 +43,7 @@ export async function generateChangelogEntry(options: {
   } = options;
 
   // Build compare URL
-  const compareUrl = previousVersion
+  const compareUrl = previousVersion && previousVersion !== version
     ? `https://github.com/${owner}/${repo}/compare/${packageName}@${previousVersion}...${packageName}@${version}`
     : undefined;
 
@@ -91,6 +91,13 @@ export async function updateChangelog(options: {
     workspacePackage,
     githubClient,
   } = options;
+
+  if (previousVersion === version) {
+    logger.verbose(
+      `Skipping changelog update for ${workspacePackage.name}: version unchanged (${version})`,
+    );
+    return;
+  }
 
   const changelogPath = join(workspacePackage.path, "CHANGELOG.md");
 

--- a/src/core/changelog.ts
+++ b/src/core/changelog.ts
@@ -43,9 +43,10 @@ export async function generateChangelogEntry(options: {
   } = options;
 
   // Build compare URL
-  const compareUrl = previousVersion && previousVersion !== version
-    ? `https://github.com/${owner}/${repo}/compare/${packageName}@${previousVersion}...${packageName}@${version}`
-    : undefined;
+  const compareUrl =
+    previousVersion && previousVersion !== version
+      ? `https://github.com/${owner}/${repo}/compare/${packageName}@${previousVersion}...${packageName}@${version}`
+      : undefined;
 
   const commitAuthors = await resolveCommitAuthors(commits, githubClient);
   const templateGroups = buildTemplateGroups({

--- a/src/workflows/prepare.ts
+++ b/src/workflows/prepare.ts
@@ -183,6 +183,13 @@ export async function prepareWorkflow(
     const changelogPromises = allUpdates
       .map((update) => {
         return (async () => {
+          if (update.currentVersion === update.newVersion) {
+            logger.verbose(
+              `Skipping changelog for ${update.package.name}: version unchanged (${update.newVersion})`,
+            );
+            return;
+          }
+
           let pkgCommits = groupedPackageCommits.get(update.package.name) || [];
           let globalCommits = globalCommitsPerPackage.get(update.package.name) || [];
           let previousVersionForChangelog: string | undefined =

--- a/test/core/changelog.test.ts
+++ b/test/core/changelog.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { generateChangelogEntry, parseChangelog, updateChangelog } from "#core/changelog";
@@ -507,5 +507,45 @@ describe("updateChangelog", () => {
     expect(parsed.versions[0]!.version).toBe("0.2.0");
     expect(content).toContain("add feature A");
     expect(content).toContain("add feature B");
+  });
+
+  it("should not rewrite the changelog when version is unchanged", async () => {
+    const testdirPath = await testdir({});
+    const context = createChangelogTestContext(testdirPath);
+
+    const existingChangelog = dedent`
+      # @ucdjs/test
+
+      ## 0.1.0 (2025-01-15)
+
+      ### Features
+
+      * initial release
+    `;
+
+    await writeFile(join(testdirPath, "CHANGELOG.md"), `${existingChangelog}\n`, "utf-8");
+
+    mockExec.mockResolvedValueOnce({ stdout: existingChangelog, stderr: "", exitCode: 0 });
+
+    await updateChangelog({
+      normalizedOptions: context.normalizedOptions,
+      workspacePackage: context.workspacePackage,
+      version: "0.1.0",
+      previousVersion: "0.1.0",
+      commits: [
+        createCommit({
+          type: "feat",
+          message: "feat: this should not be written",
+          hash: "def456",
+          shortHash: "def456",
+        }),
+      ],
+      date: "2025-01-16",
+      githubClient: context.githubClient,
+    });
+
+    const content = await readFile(join(testdirPath, "CHANGELOG.md"), "utf-8");
+
+    expect(content).toBe(`${existingChangelog}\n`);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent unnecessary changelog file rewrites when version numbers remain unchanged, reducing unnecessary file operations
  * Fixed generation of self-referencing comparison URLs in changelog entries when versions are identical

* **Tests**
  * Added test coverage for scenarios where version numbers remain unchanged between releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->